### PR TITLE
Removing dependency of site living in root directory

### DIFF
--- a/Ember.Handlebars/EmberHandlebarsBundleTransform.cs
+++ b/Ember.Handlebars/EmberHandlebarsBundleTransform.cs
@@ -39,8 +39,15 @@ public class EmberHandlebarsBundleTransform : IBundleTransform {
             var virtual_root = assetFile.IncludedVirtualPath
                               .Substring( 0, assetFile.IncludedVirtualPath.IndexOf( "\\" ) );
 
-            var virtual_file_path = string.Format("~{0}", assetFile.VirtualFile.VirtualPath)
-                                          .Replace( virtual_root + "/", string.Empty );
+            var virtual_file_path = string.Format("~{0}", assetFile.VirtualFile.VirtualPath);
+
+            var application_path = HttpContext.Current != null ? HttpContext.Current.Request.ApplicationPath : "/";
+
+            var app_less_virtual_file_path = virtual_file_path.Replace("~" + application_path, String.Empty).TrimStart('/');
+
+            virtual_file_path = string.Format("~/{0}", app_less_virtual_file_path)
+                                    .Replace(virtual_root + "/", string.Empty);
+                                    
             var file_extension    = virtual_file_path.Substring(virtual_file_path.LastIndexOf("."));
             
             var template_directory_name = string.Empty;


### PR DESCRIPTION
If a site lives in an application (instead of the root of the site) the process method will fail due to an invalid path derived from the root of the site, not the root of the application.

www.site.com/app1
www.site.com/app2 (completely separate site from app1, can have different app pool etc)

http://www.iis.net/learn/get-started/planning-your-iis-architecture/understanding-sites-applications-and-virtual-directories-on-iis#About7.0
