### PR TITLE
Adding the ability to handle ember components

### DIFF
--- a/Ember.Handlebars.ExampleWebAPI/Ember.Handlebars.ExampleWebAPI.csproj
+++ b/Ember.Handlebars.ExampleWebAPI/Ember.Handlebars.ExampleWebAPI.csproj
@@ -182,6 +182,7 @@
     <Content Include="Scripts\app\templates\shows\show\remove.hbs" />
     <Content Include="Scripts\app\templates\_show_details.hbs" />
     <Content Include="Scripts\app\templates\_flash.hbs" />
+    <Content Include="Scripts\app\templates\component\some-component.hbs" />
     <None Include="Scripts\jquery-1.9.1.intellisense.js" />
     <Content Include="Scripts\app\routes\app_home_route.js" />
     <Content Include="Scripts\app\routes\app_route.js" />

--- a/Ember.Handlebars.ExampleWebAPI/Scripts/app/templates/component/some-component.hbs
+++ b/Ember.Handlebars.ExampleWebAPI/Scripts/app/templates/component/some-component.hbs
@@ -1,0 +1,3 @@
+﻿<H1>
+  I am a component
+</H1>

--- a/Ember.Handlebars/EmberHandlebarsBundleTransform.cs
+++ b/Ember.Handlebars/EmberHandlebarsBundleTransform.cs
@@ -8,7 +8,7 @@ public class EmberHandlebarsBundleTransform : IBundleTransform {
     
     private string defaultTemplateName   = "default";
     private string resourceNameSeparator = "/";
-    private string fileNameSeparator     = "-";
+    private string fileNameSeparator     = "--";
     private bool   minifyTemplates       = true;
     
     public string DefaultTemplateName {

--- a/Ember.Handlebars/EmberHelpers.cs
+++ b/Ember.Handlebars/EmberHelpers.cs
@@ -8,8 +8,10 @@ using Ember;
 
 public static class HtmlHelperExtensions
 {
+    private const string directoryToken = "<dir-seperator>";
     public static IHtmlString RenderEmberTemplates(this HtmlHelper helper, string path = "", bool noTemplateName = false)
     {
+        
         var templateFolder = EmberJs.ServerMappedTemplatesPath;
 
         if (BundleTable.EnableOptimizations)
@@ -81,7 +83,7 @@ public static class HtmlHelperExtensions
             }
             if (relativeDirName.Length > 0 && relativeDirName[relativeDirName.Length - 1] != '-')
             {
-                relativeDirName += "-";
+                relativeDirName += directoryToken;
             }
             content += ReadTemplate(relativeDirName + subtemplateName, templateFile);
         }
@@ -103,7 +105,7 @@ public static class HtmlHelperExtensions
             return "<script type=\"text/x-handlebars\">\n" + content + "\n</script>\n";
         }
 
-        templateName = templateName.Replace("-", "/");
+        templateName = templateName.Replace(directoryToken, "/");
         var segments = templateName.Split('/');
         if (segments.Length > 2) {
             templateName = string.Format("{0}/{1}", segments[segments.Length - 2], segments[segments.Length - 1]);


### PR DESCRIPTION
instead of using the dash we use either double dash for the
fileNameSeparator, and a unique token on the emberhelper
